### PR TITLE
Align CirclesToRhombuses properly

### DIFF
--- a/src/components/lib/CirclesToRhombusesSpinner.vue
+++ b/src/components/lib/CirclesToRhombusesSpinner.vue
@@ -58,6 +58,10 @@
             animationDelay: `${i * delay}ms`
           }, this.circleStyle)
 
+          if (i === 1) {
+            style.marginLeft = 0
+          }
+
           circlesStyles.push(style)
         }
 


### PR DESCRIPTION
Apply `margin-left: 0` for the `first-child` circle (just like in css)

I think it's possible to keep `spinnertStyle` w/o changes because of corners of first and last elements 

Issue is reproducible here: http://epic-spinners.epicmax.co/#/

![screenshot](https://image.prntscr.com/image/eZFuVmVqTx2qOT-72lAthQ.png)