### PR TITLE
update default for atomspinner

### DIFF
--- a/src/components/lib/AtomSpinner.vue
+++ b/src/components/lib/AtomSpinner.vue
@@ -28,7 +28,7 @@
       },
       color: {
         type: String,
-        default: 'red'
+        default: '#fff'
       }
     },
 


### PR DESCRIPTION
All other spinners use `#fff` as dfault color but atomspinner had `red` as default. 